### PR TITLE
Provided labels for various data

### DIFF
--- a/src/constants/misc_constants.asm
+++ b/src/constants/misc_constants.asm
@@ -2,3 +2,7 @@
 CONSOLE_DMG                 EQU $00
 CONSOLE_SGB                 EQU $01
 CONSOLE_CGB                 EQU $02
+
+; dueling constants
+PLAYER_TURN					EQU $c2
+OPPONENT_TURN				EQU $c3

--- a/src/constants/misc_constants.asm
+++ b/src/constants/misc_constants.asm
@@ -4,5 +4,5 @@ CONSOLE_SGB                 EQU $01
 CONSOLE_CGB                 EQU $02
 
 ; dueling constants
-PLAYER_TURN					EQU $c2
-OPPONENT_TURN				EQU $c3
+PLAYER_TURN   EQUS "wPlayerDuelVariables >> $8"
+OPPONENT_TURN EQUS "wOpponentDuelVariables >> $8"

--- a/src/engine/bank1.asm
+++ b/src/engine/bank1.asm
@@ -47,7 +47,7 @@ INCBIN "baserom.gbc",$406f,$409f - $406f
 ; this function begins the duel after the opponent's
 ; graphics, name and deck have been introduced
 StartDuel: ; 409f (1:409f)
-	ld a, $c2
+	ld a, PLAYER_TURN
 	ldh [hWhoseTurn], a
 	ld a, $0
 	ld [$c2f1], a
@@ -74,7 +74,7 @@ StartDuel: ; 409f (1:409f)
 	ld a, h
 	ld [$cbe6], a
 	xor a
-	ld [$cbc6], a
+	ld [wBattleMenuSelection], a
 	call $420b
 	ld a, [$cc18]
 	ld [$cc08], a
@@ -87,19 +87,19 @@ StartDuel: ; 409f (1:409f)
 ; the loop returns here after every turn switch
 .mainDuelLoop
 	xor a
-	ld [$cbc6], a
+	ld [wBattleMenuSelection], a
 	call $35e6
 	call $54c8
 	call $4225
 	call $0f58
-	ld a, [$cc07]
+	ld a, [wBattleFinished]
 	or a
 	jr nz, .asm_4136
 	call $35fa
 	call $6baf
 	call $3b31
 	call $0f58
-	ld a, [$cc07]
+	ld a, [wBattleFinished]
 	or a
 	jr nz, .asm_4136
 	ld hl, $cc06
@@ -107,6 +107,7 @@ StartDuel: ; 409f (1:409f)
 	ld a, [$cc09]
 	cp $80
 	jr z, .asm_4126
+	
 .asm_4121
 	call GetOpposingTurnDuelistVariable_SwapTurn
 	jr .mainDuelLoop
@@ -132,28 +133,28 @@ StartDuel: ; 409f (1:409f)
 	call Func_04a2
 	ldh a, [hWhoseTurn]
 	push af
-	ld a, $c2
+	ld a, PLAYER_TURN
 	ldh [hWhoseTurn], a
 	call $4a97
 	call $4ad6
 	pop af
 	ldh [hWhoseTurn], a
 	call $3b21
-	ld a, [$cc07]
+	ld a, [wBattleFinished]
 	cp $1
-	jr z, .asm_4171
+	jr z, .activeDuelistWonBattle
 	cp $2
-	jr z, .asm_4184
+	jr z, .activeDuelistLostBattle
 	ld a, $5f
 	ld c, $1a
 	ld hl, $0077
 	jr .asm_4196
 
-.asm_4171
+.activeDuelistWonBattle
 	ldh a, [hWhoseTurn]
-	cp $c2
-	jr nz, .asm_418a
-.asm_4177
+	cp PLAYER_TURN
+	jr nz, .opponentWonBattle
+.playerWonBattle
 	xor a
 	ld [$d0c3], a
 	ld a, $5d
@@ -161,12 +162,12 @@ StartDuel: ; 409f (1:409f)
 	ld hl, $0078
 	jr .asm_4196
 
-.asm_4184
+.activeDuelistLostBattle
 	ldh a, [hWhoseTurn]
-	cp $c2
-	jr nz, .asm_4177
+	cp PLAYER_TURN
+	jr nz, .playerWonBattle
 
-.asm_418a
+.opponentWonBattle
 	ld a, $1
 	ld [$d0c3], a
 	ld a, $5e
@@ -177,7 +178,7 @@ StartDuel: ; 409f (1:409f)
 	call $3b6a
 	ld a, c
 	call PlaySong
-	ld a, $c3
+	ld a, OPPONENT_TURN
 	ldh [hWhoseTurn], a
 	call DrawWideTextBox_PrintText
 	call EnableLCD
@@ -186,14 +187,14 @@ StartDuel: ; 409f (1:409f)
 	call Func_378a
 	or a
 	jr nz, .asm_41a7
-	ld a, [$cc07]
+	ld a, [wBattleFinished]
 	cp $3
 	jr z, .asm_41c8
 	call Func_39fc
 	call WaitForWideTextBoxInput
 	call $3b31
 	call ResetSerial
-	ld a, $c2
+	ld a, PLAYER_TURN
 	ldh [hWhoseTurn], a
 	ret
 
@@ -210,18 +211,18 @@ StartDuel: ; 409f (1:409f)
 	ld a, [$cc09]
 	cp $1
 	jr z, .asm_41f3
-	ld a, $c2
+	ld a, PLAYER_TURN
 	ldh [hWhoseTurn], a
 	call $4b60
 	jp $40ee
 
 .asm_41f3
 	call $0f58
-	ld h, $c2
+	ld h, PLAYER_TURN
 	ld a, [wSerialOp]
 	cp $29
 	jr z, .asm_4201
-	ld h, $c3
+	ld h, OPPONENT_TURN
 
 .asm_4201
 	ld a, h

--- a/src/engine/bank3.asm
+++ b/src/engine/bank3.asm
@@ -26,7 +26,7 @@ LoadMap: ; c000 (3:4000)
 	call Func_c241
 	call Func_04a2
 	call Func_3ca0
-	ld a, $c2
+	ld a, PLAYER_TURN
 	ldh [hWhoseTurn], a
 	farcall Func_1c440
 	ld a, [$d0bb]
@@ -391,7 +391,7 @@ Func_c2db: ; c2db (3:42db)
 	call Set_OBJ_8x8
 	call Func_3ca0
 	farcall Func_12bcd
-	ld a, $c2
+	ld a, PLAYER_TURN
 	ldh [hWhoseTurn], a
 	call Func_c241
 	call Func_04a2

--- a/src/engine/bank4.asm
+++ b/src/engine/bank4.asm
@@ -694,7 +694,7 @@ Func_126d1: ; 126d1 (4:66d1)
 	ld a, $ff
 	ld [$d627], a
 .asm_126e1
-	ld a, $c2
+	ld a, PLAYER_TURN
 	ldh [hWhoseTurn], a
 	farcall Func_c1f8
 	farcall Func_1d078

--- a/src/engine/bank6.asm
+++ b/src/engine/bank6.asm
@@ -6,7 +6,7 @@ INCBIN "baserom.gbc",$18f9c,$1996e - $18f9c
 
 Func_1996e: ; 1996e (6:596e)
 	call EnableExtRAM
-	ld a, $c2
+	ld a, PLAYER_TURN
 	ldh [hWhoseTurn], a
 	ld hl, $a100
 	ld bc, $1607
@@ -154,7 +154,7 @@ Func_1a61f: ; 1a61f (6:661f)
 	ld h, [hl]
 	ld l, a
 	bank1call $2ebb
-	ld a, $c2
+	ld a, PLAYER_TURN
 	ldh [hWhoseTurn], a
 	pop hl
 	bank1call $5e5f

--- a/src/engine/home.asm
+++ b/src/engine/home.asm
@@ -2078,7 +2078,7 @@ INCBIN "baserom.gbc",$0ebf,$1072 - $0ebf
 CopyDeckData: ; 1072 (0:1072)
 	ld hl, wPlayerDeck
 	ldh a, [hWhoseTurn]
-	cp $c2
+	cp PLAYER_TURN
 	jr z, .copyDeckData
 	ld hl, wOpponentDeck
 .copyDeckData
@@ -2257,10 +2257,10 @@ GetTurnDuelistVariable: ; 160b (0:160b)
 GetOpposingTurnDuelistVariable: ; 1611 (0:1611)
 	ld l, a
 	ldh a, [hWhoseTurn]
-	ld h, $c3
-	cp $c2
+	ld h, OPPONENT_TURN
+	cp PLAYER_TURN
 	jr z, .asm_161c
-	ld h, $c2
+	ld h, PLAYER_TURN
 .asm_161c
 	ld a, [hl]
 	ret
@@ -3986,7 +3986,7 @@ Func_2e2c: ; 2e2c (0:2e2c)
 	ld de, $caa0
 	push de
 	ldh a, [hWhoseTurn]
-	cp $c3
+	cp OPPONENT_TURN
 	jp z, .opponentTurn
 	call PrintPlayerName
 	pop hl
@@ -4066,7 +4066,7 @@ PrintTextBoxBorderLabel: ; 2e89 (0:2e89)
 	ret
 .special
 	ldh a, [hWhoseTurn]
-	cp $c3
+	cp OPPONENT_TURN
 	jp z, PrintOpponentName
 	jp PrintPlayerName
 ; 0x2ea9

--- a/src/wram.asm
+++ b/src/wram.asm
@@ -268,10 +268,23 @@ wSerialRecvIndex:: ; cba4
 
 wSerialRecvBuf:: ; $cba5 - $cbc4
 	ds $20
-	ds $49
+	ds $1
+
+
 
 ;--- Duels 2 ----------------------------------------------
 
+wBattleMenuSelection:: ; $cbc6
+	ds $1
+	ds $40
+
+; 0 = no one has won battle yet
+; 1 = player whose turn it is has won the battle
+; 2 = player whose turn it is has lost the battle
+wBattleFinished:: ; $cc07
+	ds $1
+	ds $6
+	
 ; this seems to hold the current opponent's deck id - 2,
 ; perhaps to account for the two unused pointers at the
 ; beginning of DeckPointers


### PR DESCRIPTION
Defined two new labels in wram.
Defined names for the oddly arbitrary values representing whose turn it
is in battle.
Renamed labels for some parts of the dueling main loop and loss
function.