### PR TITLE
create text_hl macro replace hardcoded text constants loads

### DIFF
--- a/src/engine/bank1.asm
+++ b/src/engine/bank1.asm
@@ -622,11 +622,11 @@ CheckIfActiveCardParalyzedOrAsleep: ; 4918 (1:4918)
 	ret
 
 .paralyzed:
-	ld hl, $0025
+	text_hl Text0025 ; paralyzed
 	jr .returnWithStatusCondition
 
 .asleep:
-	ld hl, $0024
+	text_hl Text0024 ; asleep
 
 .returnWithStatusCondition:
 	scf

--- a/src/engine/bank1.asm
+++ b/src/engine/bank1.asm
@@ -22,7 +22,7 @@ Func_4000: ; 4000 (1:4000)
 .asm_4035
 	call Func_405a
 	call Func_04a2
-	ld hl, $00a2
+	text_hl Text00a2 ; reset back up ram?
 	call Func_2af0
 	jr c, .asm_404d
 	call EnableExtRAM
@@ -128,7 +128,7 @@ StartDuel: ; 409f (1:409f)
 	call Func_04a2
 	ld a, $3
 	call Func_2167
-	ld hl, $0076
+	text_hl Text0076 ; decision...
 	call DrawWideTextBox_WaitForInput
 	call Func_04a2
 	ldh a, [hWhoseTurn]
@@ -147,7 +147,7 @@ StartDuel: ; 409f (1:409f)
 	jr z, .activeDuelistLostBattle
 	ld a, $5f
 	ld c, $1a
-	ld hl, $0077
+	text_hl Text0077 ; duel was a draw
 	jr .asm_4196
 
 .activeDuelistWonBattle
@@ -159,7 +159,7 @@ StartDuel: ; 409f (1:409f)
 	ld [$d0c3], a
 	ld a, $5d
 	ld c, $18
-	ld hl, $0078
+	text_hl Text0078 ; won duel
 	jr .asm_4196
 
 .activeDuelistLostBattle
@@ -172,7 +172,7 @@ StartDuel: ; 409f (1:409f)
 	ld [$d0c3], a
 	ld a, $5e
 	ld c, $19
-	ld hl, $0079
+	text_hl Text0079 ; lost duel
 
 .asm_4196
 	call Func_3b6a
@@ -203,7 +203,7 @@ StartDuel: ; 409f (1:409f)
 	call Func_3b31
 	ld a, [wDuelTheme]
 	call PlaySong
-	ld hl, $007a
+	text_hl Text007a ; sudden-death match
 	call DrawWideTextBox_WaitForInput
 	ld a, $1
 	ld [$cc08], a
@@ -282,7 +282,7 @@ Func_426d:
 	xor a
 	ld [wVBlankCtr], a
 	ld [$cbf9], a
-	ld hl, $0088
+	text_hl Text0088 ; is thinking
 	call Func_2a36
 	call Func_2bbf
 	ld a, $ff
@@ -413,7 +413,7 @@ PlayerRetreat: ; 43ab (1:43ab)
 	jr c, Func_441f
 	call $4611
 	jr c, Func_441c
-	ld hl, $010e
+	text_hl Text010e ; select pokemon on bench to switch
 	call DrawWideTextBox_WaitForInput
 	call $600c
 	jr c, Func_441c
@@ -427,7 +427,7 @@ PlayerRetreat: ; 43ab (1:43ab)
 	call $4f9d
 
 Func_43e8: ; 43e8
-	ld hl, $003d
+	text_hl Text003d ; unable to retreat
 	call DrawWideTextBox_WaitForInput
 	jp Func_4295
 
@@ -437,7 +437,7 @@ Func_43f1: ; 43f1 (1:43f1)
 	call $4611
 	jr c, Func_441c
 	call $6558
-	ld hl, $010e
+	text_hl Text010e ; select pokemon on bench to switch
 	call DrawWideTextBox_WaitForInput
 	call $600c
 	ld [wBenchSelectedPokemon], a
@@ -462,7 +462,7 @@ OpenHandMenu: ; 4425 (1:4425)
 	call GetTurnDuelistVariable
 	or a
 	jr nz, Func_4436
-	ld hl, $00a4
+	text_hl Text00a4 ; no cards in hand
 	call DrawWideTextBox_WaitForInput
 	jp Func_4295
 
@@ -494,7 +494,7 @@ OpenBattleAttackMenu: ; 46fc (1:46fc)
 	call $4823
 	or a
 	jr nz, .asm_471f
-	ld hl, $003c
+	text_hl Text003c ; no selectable attack
 	call DrawWideTextBox_WaitForInput
 	jp Func_4295
 
@@ -523,7 +523,7 @@ OpenBattleAttackMenu: ; 46fc (1:46fc)
 	ld [wSelectedDuelSubMenuItem], a
 	call $488f
 	jr nc, .asm_4759
-	ld hl, $00c0
+	text_hl Text00c0 ; not enough energy cards
 	call DrawWideTextBox_WaitForInput
 	jr .tryOpenAttackMenu
 

--- a/src/engine/bank2.asm
+++ b/src/engine/bank2.asm
@@ -81,7 +81,7 @@ Func_8db0: ; 8db0 (2:4db0)
 Func_8dbc: ; 8dbc (2:4dbc)
 	ld hl, Unknown_8de2
 	call InitializeCursorParameters
-	ld hl, $0224
+	text_hl Text0224
 	call DrawWideTextBox_PrintText
 .asm_8dc8
 	call DoFrame
@@ -348,13 +348,13 @@ Func_8f9d: ; 8f9d (2:4f9d)
 	xor a
 	ld [$ce3f], a
 	ld [$ce40], a
-	ld hl, $022a
+	text_hl Text022a
 	call DrawWideTextBox_WaitForInput
 	ld a, [$ceb1]
 	jp Func_8dbc
 
 Func_8fe8: ; 8fe8 (2:4fe8)
-	ld hl, $022f
+	text_hl Text022f
 	call DrawWideTextBox_WaitForInput
 	ld a, [$ceb1]
 	ret
@@ -703,7 +703,7 @@ Func_926e: ; 926e (2:526e)
 	ret
 .asm_929c
 	call Func_22ae
-	ld hl, $0223
+	text_hl Text0223
 	call Func_2c29
 	scf
 	ret

--- a/src/engine/bank3.asm
+++ b/src/engine/bank3.asm
@@ -1034,7 +1034,7 @@ PC_c7ea: ; c7ea (3:47ea)
 	call Func_c241
 	call $4915
 	call DoFrameIfLCDEnabled
-	ld hl, $0352
+	text_hl Text0352 ; turned PC on
 	call Func_2c73
 	call $484e
 .asm_c801
@@ -1061,7 +1061,7 @@ PC_c7ea: ; c7ea (3:47ea)
 .asm_c82f
 	call Func_c135
 	call DoFrameIfLCDEnabled
-	ld hl, $0353
+	text_hl Text0353 ; turned PC off
 	call $4891
 	call Func_c111
 	xor a

--- a/src/engine/bank4.asm
+++ b/src/engine/bank4.asm
@@ -49,7 +49,7 @@ Medal_1029e: ; 1029e (4:429e)
 	ld a, [$d116]
 	cp $e0
 	jr nz, .asm_102e2
-	ld hl, $038b
+	text_hl Text038b
 	call Func_2c73
 	call Func_3c96
 	call Func_37a0
@@ -101,16 +101,16 @@ BoosterPack_1031b: ; 1031b (4:431b)
 	pop bc
 	ld a, c
 	farcallx $7, $61c4
-	ld hl, $0387
+	text_hl Text0387
 	ld a, [$d117]
 	cp $1
 	jr nz, .asm_10373
-	ld hl, $0388
+	text_hl Text0388
 .asm_10373
 	call Func_2c73
 	call Func_3c96
 	call Func_37a0
-	ld hl, $0389
+	text_hl Text0389
 	call Func_2c73
 	call DisableLCD
 	call Func_1288c
@@ -1115,7 +1115,7 @@ Func_1344d: ; 1344d (4:744d)
 	call Func_379b
 	ld a, MUSIC_MEDAL
 	call PlaySong
-	ld hl, $07e6
+	text_hl Text07e6
 	call Func_2c73
 	call Func_3c96
 	call Func_37a0
@@ -1137,7 +1137,7 @@ Func_13485: ; 13485 (4:7485)
 	call Func_379b
 	ld a, MUSIC_MEDAL
 	call PlaySong
-	ld hl, $07e8
+	text_hl Text07e8
 	call Func_2c73
 	call Func_3c96
 	call Func_37a0

--- a/src/engine/bank6.asm
+++ b/src/engine/bank6.asm
@@ -124,23 +124,23 @@ Func_1a61f: ; 1a61f (6:661f)
 	ld a, $76
 	call $663b
 	ld a, $c1
-	ld hl, $0191
+	text_hl Text0191
 	jr .asm_1a660
 .asm_1a640
-	ld hl, $018f
+	text_hl Text018f
 	cp $1e
 	jr z, .asm_1a660
 	cp $43
 	jr z, .asm_1a660
-	ld hl, $0192
+	text_hl Text0192
 	cp $64
 	jr z, .asm_1a660
-	ld hl, $0193
+	text_hl Text0193
 	cp $65
 	jr z, .asm_1a660
 	cp $66
 	jr z, .asm_1a660
-	ld hl, $0190
+	text_hl Text0190
 .asm_1a660
 	push hl
 	ld e, a

--- a/src/engine/home.asm
+++ b/src/engine/home.asm
@@ -408,10 +408,10 @@ SetupPalettes: ; 036a (0:036a)
 	ret
 
 InitialPalette: ; 0399 (0:0399)
-	RGB 28,28,24
-	RGB 21,21,16
-	RGB 10,10,08
-	RGB 00,00,00
+	rgb 28,28,24
+	rgb 21,21,16
+	rgb 10,10,08
+	rgb 00,00,00
 
 SetupVRAM: ; 03a1 (0:03a1)
 	call FillTileMap
@@ -626,7 +626,7 @@ Func_04a2: ; 04a2 (0:04a2)
 	ret
 
 SGB_ATTR_BLK_04bf: ; 04bf (0:04bf)
-	SGB ATTR_BLK, 1 ; sgb_command, length
+	sgb ATTR_BLK, 1 ; sgb_command, length
 	db $01,$03,$00,$00,$00,$13,$11,$00,$00,$00,$00,$00,$00,$00,$00
 
 Func_04cf: ; 04cf (0:04cf)
@@ -1515,55 +1515,55 @@ InitSGB: ; 0a0d (0:0a0d)
 	ret
 
 SGB_DATA_SND_0a50: ; 0a50 (0:0a50)
-	SGB DATA_SND, 1 ; sgb_command, length
+	sgb DATA_SND, 1 ; sgb_command, length
 	db $5d,$08,$00,$0b,$8c,$d0,$f4,$60,$00,$00,$00,$00,$00,$00,$00
 
 SGB_DATA_SND_0a60: ; 0a60 (0:0a60)
-	SGB DATA_SND, 1 ; sgb_command, length
+	sgb DATA_SND, 1 ; sgb_command, length
 	db $52,$08,$00,$0b,$a9,$e7,$9f,$01,$c0,$7e,$e8,$e8,$e8,$e8,$e0
 
 SGB_DATA_SND_0a70: ; 0a70 (0:0a70)
-	SGB DATA_SND, 1 ; sgb_command, length
+	sgb DATA_SND, 1 ; sgb_command, length
 	db $47,$08,$00,$0b,$c4,$d0,$16,$a5,$cb,$c9,$05,$d0,$10,$a2,$28
 
 SGB_DATA_SND_0a80: ; 0a80 (0:0a80)
-	SGB DATA_SND, 1 ; sgb_command, length
+	sgb DATA_SND, 1 ; sgb_command, length
 	db $3c,$08,$00,$0b,$f0,$12,$a5,$c9,$c9,$c8,$d0,$1c,$a5,$ca,$c9
 
 SGB_DATA_SND_0a90: ; 0a90 (0:0a90)
-	SGB DATA_SND, 1 ; sgb_command, length
+	sgb DATA_SND, 1 ; sgb_command, length
 	db $31,$08,$00,$0b,$0c,$a5,$ca,$c9,$7e,$d0,$06,$a5,$cb,$c9,$7e
 
 SGB_DATA_SND_0aa0: ; 0aa0 (0:0aa0)
-	SGB DATA_SND, 1 ; sgb_command, length
+	sgb DATA_SND, 1 ; sgb_command, length
 	db $26,$08,$00,$0b,$39,$cd,$48,$0c,$d0,$34,$a5,$c9,$c9,$80,$d0
 
 SGB_DATA_SND_0ab0: ; 0ab0 (0:0ab0)
-	SGB DATA_SND, 1 ; sgb_command, length
+	sgb DATA_SND, 1 ; sgb_command, length
 	db $1b,$08,$00,$0b,$ea,$ea,$ea,$ea,$ea,$a9,$01,$cd,$4f,$0c,$d0
 
 SGB_DATA_SND_0ac0: ; 0ac0 (0:0ac0)
-	SGB DATA_SND, 1 ; sgb_command, length
+	sgb DATA_SND, 1 ; sgb_command, length
 	db $10,$08,$00,$0b,$4c,$20,$08,$ea,$ea,$ea,$ea,$ea,$60,$ea,$ea
 
 SGB_MASK_EN_ON: ; 0ad0 (0:0ad0)
-	SGB MASK_EN, 1 ; sgb_command, length
+	sgb MASK_EN, 1 ; sgb_command, length
 	db $01,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00
 
 SGB_MASK_EN_OFF: ; 0ae0 (0:0ae0)
-	SGB MASK_EN, 1 ; sgb_command, length
+	sgb MASK_EN, 1 ; sgb_command, length
 	db $00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00
 
 SGB_PAL01: ; 0af0 (0:0af0)
-	SGB PAL01, 1 ; sgb_command, length
+	sgb PAL01, 1 ; sgb_command, length
 	db $9c,$63,$94,$42,$08,$21,$00,$00,$1f,$00,$0f,$00,$07,$00,$00
 
 SGB_PAL23: ; 0b00 (0:0b00)
-	SGB PAL23, 1 ; sgb_command, length
+	sgb PAL23, 1 ; sgb_command, length
 	db $e0,$03,$e0,$01,$e0,$00,$00,$00,$00,$7c,$00,$3c,$00,$1c,$00
 
 SGB_ATTR_BLK_0b10: ; 0b10 (0:0b10)
-	SGB ATTR_BLK, 1 ; sgb_command, length
+	sgb ATTR_BLK, 1 ; sgb_command, length
 	db $01,$03,$09,$05,$05,$0a,$0a,$00,$00,$00,$00,$00,$00,$00,$00
 
 ; send SGB command
@@ -1652,11 +1652,11 @@ DetectSGB: ; 0b59 (0:0b59)
 	ret
 
 SGB_MLT_REQ_1: ; 0bab (0:0bab)
-	SGB MLT_REQ, 1 ; sgb_command, length
+	sgb MLT_REQ, 1 ; sgb_command, length
 	db $00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00
 
 SGB_MLT_REQ_2: ; 0bbb (0:0bbb)
-	SGB MLT_REQ, 1 ; sgb_command, length
+	sgb MLT_REQ, 1 ; sgb_command, length
 	db $01,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00
 
 INCBIN "baserom.gbc",$0bcb,$0c08 - $0bcb
@@ -3450,7 +3450,7 @@ ColorizeTextBoxSGB
 	ret
 
 SGB_ATTR_BLK_1f4f: ; 1f4f (0:1f4f)
-	SGB ATTR_BLK, 1 ; sgb_command, length
+	sgb ATTR_BLK, 1 ; sgb_command, length
 	db $01,$03,$04,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00
 
 Func_1f5f: ; 1f5f (0:1f5f)

--- a/src/engine/home.asm
+++ b/src/engine/home.asm
@@ -5877,13 +5877,13 @@ CheckIfCantAttackDueToAttackEffect:: ; 33c1 (0:33c1)
 	call GetTurnDuelistVariable
 	or a
 	ret z
-	ld hl, $0100 ;tail wag
+	text_hl Text0100 ;tail wag
 	cp $05
 	jr z, .returnWithCantAttack
-	ld hl, $0101 ;leer
+	text_hl Text0101 ;leer
 	cp $06
 	jr z, .returnWithCantAttack
-	ld hl, $0102 ;bone attack
+	text_hl Text0102 ;bone attack
 	cp $0b
 	jr z, .returnWithCantAttack
 	or a

--- a/src/engine/home.asm
+++ b/src/engine/home.asm
@@ -2099,7 +2099,7 @@ Func_0f35: ; 0f35 (0:0f35)
 	ld l, a
 	ld h, $0
 	call Func_2ec4
-	ld hl, $0055
+	text_hl Text0055 ; transmission error
 	call DrawWideTextBox_WaitForInput
 	ld a, $ff
 	ld [wd0c3], a
@@ -2671,7 +2671,7 @@ Func_1828: ; 1828 (0:1828)
 	bank1call $4f9d
 	ld a, $1
 	ld [wcce6], a
-	ld hl, $004f
+	text_hl Text004f ; 20 self-confusion damage
 	call DrawWideTextBox_PrintText
 	ld a, $75
 	ld [wccb8], a
@@ -3017,7 +3017,7 @@ Func_1ad3: ; 1ad3 (0:1ad3)
 	ld h, [hl]
 	ld l, a
 	call Func_2ebb
-	ld hl, $0081
+	text_hl Text0081 ; was knocked out
 	call DrawWideTextBox_PrintText
 	ld a, $28
 .asm_1aeb
@@ -3046,7 +3046,7 @@ Func_1b8d: ; 1b8d (0:1b8d)
 	ld [hli], a
 	ld a, [wccab]
 	ld [hli], a
-	ld hl, $0035
+	text_hl Text0035 ; text when using an attack (?)
 	call DrawWideTextBox_PrintText
 	ret
 
@@ -3083,7 +3083,7 @@ Func_1bca: ; 1bca (0:1bca)
 	inc de
 	ld a, [hli]
 	ld [de], a
-	ld hl, $014a
+	text_hl Text014a ; was unsuccessful
 	call DrawWideTextBox_PrintText
 	scf
 	ret
@@ -3138,7 +3138,7 @@ PrintOpponentName: ; 1c8e (0:1c8e)
 	jr z, .printPlayer2
 	jr printNameLoop
 .printPlayer2
-	ld hl, $0092
+	text_hl Text0092 ; player 2
 	jp PrintTextBoxBorderLabel
 ; 0x1caa
 
@@ -4639,7 +4639,7 @@ Func_2af0: ; 2af0 (0:2af0)
 
 Func_2b66: ; 2b66 (0:2b66)
 	call AdjustCoordinatesForWindow
-	ld hl, $002f
+	text_hl Text002f ; yes no
 	call Func_2c1b
 	ret
 ; 0x2b70
@@ -5877,13 +5877,13 @@ CheckIfCantAttackDueToAttackEffect:: ; 33c1 (0:33c1)
 	call GetTurnDuelistVariable
 	or a
 	ret z
-	text_hl Text0100 ;tail wag
+	text_hl Text0100 ; tail wag
 	cp $05
 	jr z, .returnWithCantAttack
-	text_hl Text0101 ;leer
+	text_hl Text0101 ; leer
 	cp $06
 	jr z, .returnWithCantAttack
-	text_hl Text0102 ;bone attack
+	text_hl Text0102 ; bone attack
 	cp $0b
 	jr z, .returnWithCantAttack
 	or a
@@ -5910,7 +5910,7 @@ Func_33e1: ; 33e1 (0:33e1)
 	ld a, [wccc6]
 	cp [hl]
 	jr nz, .asm_33ee
-	ld hl, $0103
+	text_hl Text0103 ; amnesia
 	scf
 	ret
 
@@ -5921,7 +5921,7 @@ Func_3400: ; 3400 (0:3400)
 	ld [wcc0a], a
 	ccf
 	ret nc
-	ld hl, $00fd
+	text_hl Text00fd ; attack unsuccessful
 	call DrawWideTextBox_WaitForInput
 	scf
 	ret
@@ -5955,15 +5955,15 @@ Func_3432: ; 3432 (0:3432)
 	ld a, $e7
 	call GetTurnDuelistVariable
 	ld e, $3
-	ld hl, $0107
+	text_hl Text0107 ; fly
 	cp $d
 	jr z, .asm_346a
 	ld e, $2
-	ld hl, $0108
+	text_hl Text0108 ; barrier
 	cp $14
 	jr z, .asm_346a
 	ld e, $1
-	ld hl, $0109
+	text_hl Text0109 ; agility
 	cp $c
 	jr z, .asm_346a
 	call Func_34ef
@@ -5991,7 +5991,7 @@ Func_3432: ; 3432 (0:3432)
 	or a
 	ret z
 	ld e, $5
-	ld hl, $010b
+	text_hl Text010b ; n shield
 	jr .asm_346a
 
 Func_348a: ; 348a (0:348a)
@@ -6015,7 +6015,7 @@ Func_348a: ; 348a (0:348a)
 	ret nc
 	ld a, $4
 	ld [wccc7], a
-	ld hl, $010c
+	text_hl Text010c ; transparency
 	scf
 	ret
 ; 0x34b7
@@ -6040,13 +6040,13 @@ Func_34f0: ; 34f0 (0:34f0)
 	ld a, DUELVARS_ARENA_CARD_STATUS
 	call GetTurnDuelistVariable
 	and $f
-	ld hl, $00cb
+	text_hl Text00cb ; sleep, paralysis or confusion
 	scf
 	jr nz, .asm_3508
 .asm_3500
 	ld a, $27
 	call Func_3509
-	ld hl, $00d4
+	text_hl Text00d4 ; toxic gas
 .asm_3508
 	ret
 
@@ -6189,7 +6189,7 @@ Func_36a2: ; 36a2 (0:36a2)
 	push af
 	push hl
 	call Func_1a96
-	ld hl, $0105
+	text_hl Text0105 ; strikes back
 	call DrawWideTextBox_PrintText
 	pop hl
 	pop af

--- a/src/macros.asm
+++ b/src/macros.asm
@@ -42,6 +42,10 @@ GLOBAL \1_
 const_value = const_value + 1
 ENDM
 
+text_hl: MACRO
+	ld hl, \1_
+ENDM
+
 SGB: MACRO
 	db \1 * 8 + \2 ; sgb_command * 8 + length
 ENDM

--- a/src/macros.asm
+++ b/src/macros.asm
@@ -30,7 +30,7 @@ emptybank: MACRO
 	endr
 ENDM
 
-RGB: MACRO
+rgb: MACRO
 	dw (\3 << 10 | \2 << 5 | \1)
 ENDM
 
@@ -46,7 +46,7 @@ text_hl: MACRO
 	ld hl, \1_
 ENDM
 
-SGB: MACRO
+sgb: MACRO
 	db \1 * 8 + \2 ; sgb_command * 8 + length
 ENDM
 


### PR DESCRIPTION
I'm thinking about renaming some text labels like I did with card names and descriptions. Any style I should follow? I was thinking about forgoing the word "text" in the label (e.g. NoCardsInHand, NotEnoughEnergyCards) since they'll always be preceded by some sort of text macro anyway. Should they be uppercase since they're just constants after all, or should I stick to upper camel case?