### PR TITLE
Gave names to a few memory locations and routines.

### DIFF
--- a/src/engine/bank4.asm
+++ b/src/engine/bank4.asm
@@ -496,7 +496,7 @@ Func_10fbc: ; 10fbc (4:4fbc)
 	ld a, $25
 	farcall Func_1299f
 	ld c, $2
-	call Func_3dbf
+	call ModifyUnknownOAMBufferProperty
 	ld a, $80
 	ld [hli], a
 	ld a, $10
@@ -534,7 +534,7 @@ Func_10fde: ; 10fde (4:4fde)
 	or a
 	jr nz, .asm_11015
 	ld c, $f
-	call Func_3dbf
+	call ModifyUnknownOAMBufferProperty
 	set 7, [hl]
 .asm_11015
 	ret
@@ -553,7 +553,7 @@ Func_11024: ; 11024 (4:5024)
 	ld a, [wd336]
 	ld [wd4cf], a
 	ld c, $f
-	call Func_3dbf
+	call ModifyUnknownOAMBufferProperty
 	set 2, [hl]
 	ld hl, Unknown_1229f
 	ld a, [wd33d]
@@ -626,7 +626,7 @@ Func_110a6: ; 110a6 (4:50a6)
 	push hl
 	push bc
 	ld c, $2
-	call Func_3dbf
+	call ModifyUnknownOAMBufferProperty
 	pop bc
 	ld a, b
 	sub [hl]
@@ -766,7 +766,7 @@ Func_11184: ; 11184 (4:5184)
 	ld a, [wd348]
 	ld e, a
 	ld c, $2
-	call Func_3dbf
+	call ModifyUnknownOAMBufferProperty
 	ld a, [wd343]
 	add d
 	ld d, a
@@ -963,9 +963,9 @@ INCLUDE "data/unknownNPCData.asm"
 INCBIN "baserom.gbc",$11f4e,$1217b - $11f4e
 
 
-PointerTable_1217b: ; 1217b (4:617b)
+OverworldScriptTable: ; 1217b (4:617b)
 	dw Func_ccbe
-	dw Func_ccc6
+	dw Func_ccc6 ; seems to end conversation with mason and starts bringing aid over
 	dw Func_ccd4 ; Seems to begin dialogue with NPCs
 	dw Func_ccdc
 	dw Func_cce9 ; opens the "start battle?" box
@@ -994,7 +994,7 @@ PointerTable_1217b: ; 1217b (4:617b)
 	dw Func_d049
 	dw Func_d04f
 	dw Func_d055
-	dw Func_d05c
+	dw OWScript_MovePlayer
 	dw Func_cee2
 	dw Func_d080
 	dw Func_d088
@@ -1255,7 +1255,7 @@ Func_12ab5: ; 12ab5 (4:6ab5)
 	push hl
 	push af
 	ld c, $5
-	call Func_3dbf
+	call ModifyUnknownOAMBufferProperty
 	pop af
 	cp [hl]
 	pop hl

--- a/src/engine/home.asm
+++ b/src/engine/home.asm
@@ -6730,9 +6730,9 @@ Func_380e: ; 380e (0:380e)
 	ret nz
 	ldh a, [hBankROM]
 	push af
-	ld a, BANK(Func_c484)
+	ld a, BANK(SetScreenScrollWram)
 	call BankswitchHome
-	call Func_c484
+	call SetScreenScrollWram
 	call Func_c554
 	ld a, BANK(Func_1c610)
 	call BankswitchHome
@@ -6875,9 +6875,9 @@ Func_3917: ; 3917 (0:3917)
 	call DisableExtRAM
 	ret
 
-Func_3927: ; 3927 (0:3927)
+GetFloorObjectFromPos: ; 3927 (0:3927)
 	push hl
-	call Func_3946
+	call FindFloorTileFromPos
 	ld a, [hl]
 	pop hl
 	ret
@@ -6885,7 +6885,8 @@ Func_3927: ; 3927 (0:3927)
 
 INCBIN "baserom.gbc",$392e,$3946 - $392e
 
-Func_3946: ; 3946 (0:3946)
+; puts a floor tile in hc given coords in bc (x,y. measured in tiles)
+FindFloorTileFromPos: ; 3946 (0:3946)
 	push bc
 	srl b
 	srl c
@@ -6895,7 +6896,7 @@ Func_3946: ; 3946 (0:3946)
 	or b
 	ld c, a
 	ld b, $0
-	ld hl, $d133
+	ld hl, wFloorObjectMap
 	add hl, bc
 	pop bc
 	ret
@@ -6913,8 +6914,12 @@ Func_395a: ; 395a (0:395a)
 Unknown_396b: ; 396b (0:396b)
 INCBIN "baserom.gbc",$396b,$3973 - $396b
 
-Unknown_3973: ; 3973 (0:3973)
-INCBIN "baserom.gbc",$3973,$397b - $3973
+; Movement offsets for scripted movements
+ScriptedMovementOffsetTable: ; 3973 (0:3973)
+	db $00, -$02 ; move 2 tiles up
+	db $02, $00 ; move 2 tiles right
+	db $00, $02 ; move 2 tiles down
+	db -$02, $00 ; move 2 tiles left
 
 Unknown_397b: ; 397b (0:397b)
 INCBIN "baserom.gbc",$397b,$3997 - $397b
@@ -7134,9 +7139,9 @@ Func_3abd: ; 3abd (0:3abd)
 
 INCBIN "baserom.gbc",$3ae8,$3aed - $3ae8
 
-; finds a pointer on a table (in bank 4) using the data after rst20 is called and jumps to it (in bank 3)
-Func_3aed: ; 3aed (0:3aed)
-	ld hl, $d413
+; finds an OWScript from the first byte and puts the next two bytes (usually arguments?) into bc
+RunOverworldScript: ; 3aed (0:3aed)
+	ld hl, wOWScriptPointer
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -7148,11 +7153,11 @@ Func_3aed: ; 3aed (0:3aed)
 	rlca
 	ld c, a
 	ld b, $0
-	ld hl, PointerTable_1217b 
+	ld hl, OverworldScriptTable 
 	add hl, bc
 	ldh a, [hBankROM]
 	push af
-	ld a, BANK(PointerTable_1217b)
+	ld a, BANK(OverworldScriptTable)
 	call BankswitchHome
 	ld a, [hli]
 	ld h, [hl]
@@ -7429,11 +7434,12 @@ Func_3d72: ; 3d72 (0:3d72)
 Func_3db7: ; 3db7 (0:3db7)
 	push bc
 	ld c, $0
-	call Func_3dbf
+	call ModifyUnknownOAMBufferProperty
 	pop bc
 	ret
 
-Func_3dbf: ; 3dbf (0:3dbf)
+; this needs to be determined after we learn more about the buffer.
+ModifyUnknownOAMBufferProperty: ; 3dbf (0:3dbf)
 	ld a, [wd4cf]
 	cp $10
 	jr c, .asm_3dc9
@@ -7449,7 +7455,7 @@ Func_3dbf: ; 3dbf (0:3dbf)
 	and $f0
 	or c
 	ld c, a
-	ld hl, $d4d0
+	ld hl, wOAMBuffer
 	add hl, bc
 	pop bc
 	ret

--- a/src/wram.asm
+++ b/src/wram.asm
@@ -787,10 +787,10 @@ wd0b4:: ; d0b4
 wd0b5:: ; d0b5
 	ds $1
 
-wd0b6:: ; d0b6
+wSCX:: ; d0b6
 	ds $1
 
-wd0b7:: ; d0b7
+wSCY:: ; d0b7
 	ds $1
 
 wd0b8:: ; d0b8
@@ -911,6 +911,7 @@ wd132:: ; d132
 	ds $1
 
 wBoosterViableCardList:: ; d133
+wFloorObjectMap:: ; map of the current room with unpassable objects (walls, NPCs, etc). Might be a permission map
 	ds $100
 
 wd233:: ; d233
@@ -919,10 +920,10 @@ wd233:: ; d233
 wd234:: ; d234
 	ds $1
 
-wd235:: ; d235
+wSCXBuffer:: ; d235
 	ds $1
 
-wd236:: ; d236
+wSCYBuffer:: ; d236
 	ds $1
 
 wd237:: ; d237
@@ -1054,11 +1055,10 @@ wd411:: ; d411
 wd412:: ; d412
 	ds $1
 
-wd413:: ; d413
-	ds $1
+wOWScriptPointer:: ; d413
+	ds $2
 
-wd414:: ; d414
-	ds $9
+	ds $8
 
 wd41d:: ; d41d
 	ds $1
@@ -1114,8 +1114,13 @@ wd4ca:: ; d4ca
 wd4cb:: ; d4cb
 	ds $4
 
+; some sort of control bit for the OAMBuffer
 wd4cf:: ; d4cf
-	ds $104
+	ds $1
+
+; this might be more of an animation buffer as I can't find any properties like which tile sprites take up are.
+wOAMBuffer:: ; d4d0
+	ds $103
 
 wd5d3:: ; d5d3
 	ds $4

--- a/src/wram.asm
+++ b/src/wram.asm
@@ -1118,7 +1118,7 @@ wd4cb:: ; d4cb
 wd4cf:: ; d4cf
 	ds $1
 
-; this might be more of an animation buffer as I can't find any properties like which tile sprites take up are.
+; this might be more of an animation buffer as I can't find any properties like which tile sprites go where.
 wOAMBuffer:: ; d4d0
 	ds $103
 


### PR DESCRIPTION
Just a few changes, but I have some questions about some naming I did. Also sorry about the comments, I can remove them if need be, but I was planning to keep them until we finish working out these scripts.

I named everything in relation to "Overworld sprites." I realize this might be kind of an improper term, as the overworld could be considered the map screen where you move from building to building. Since the same scripts are run on the map and in buildings, I figured they could both more or less be overworlds

Also I'm planning to prefix everything in the overworld script table with OWScript_, if that seems cumbersome then I'll think of different names.

Anyway, is there any better way to name these? I'm very bad with names so please let me know if I'm not naming things well :P