### PR TITLE
Fix warnings about deprecated mnemonics on newer builds of rgbds

### DIFF
--- a/src/audio/music1.asm
+++ b/src/audio/music1.asm
@@ -593,7 +593,7 @@ Music1_PlayNextNote: ; f4414 (3d:4414)
 	ld h, d
 	ld l, e
 	pop af
-	jp [hl]
+	jp hl
 
 Music1_CommandTable: ; f442c (3d:442c)
 	dw Music1_speed

--- a/src/audio/music2.asm
+++ b/src/audio/music2.asm
@@ -593,7 +593,7 @@ Music2_PlayNextNote: ; f8414 (3e:4414)
 	ld h, d
 	ld l, e
 	pop af
-	jp [hl]
+	jp hl
 
 Music2_CommandTable: ; f842c (3e:442c)
 	dw Music2_speed

--- a/src/audio/sfx.asm
+++ b/src/audio/sfx.asm
@@ -117,7 +117,7 @@ Func_fc094: ; fc094 (3f:4094)
 	ld d, [hl]
 	ld h, d
 	ld l, e
-	jp [hl]
+	jp hl
 
 SFX_CommandTable: ; fc0ab (3f:40ab)
 	dw SFX_0

--- a/src/engine/bank1.asm
+++ b/src/engine/bank1.asm
@@ -68,7 +68,7 @@ StartDuel: ; 409f (1:409f)
 	ld [wIsPracticeDuel], a
 
 .asm_40ca
-	ld hl, [sp+$0]
+	ld hl, sp+$0
 	ld a, l
 	ld [wcbe5], a
 	ld a, h

--- a/src/engine/bank3.asm
+++ b/src/engine/bank3.asm
@@ -91,7 +91,7 @@ Func_c0ce: ; c0ce (3:40ce)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 PointerTable_c0e0: ; c0e0 (3:40e0)
 	dw Func_c0e8
@@ -124,7 +124,7 @@ Func_c10a: ; c10a (3:410a)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 ; closes dialogue window. seems to be for other things as well.
 CloseDialogueBox: ; c111 (3:4111)
@@ -1299,7 +1299,7 @@ Func_c9c0: ; c9c0 (3:49c0)
 Func_c9c2: ; c9c2 (3:49c2)
 	call Func_3abd
 	ret nc
-	jp [hl]
+	jp hl
 
 Func_c9c7: ; c9c7 (3:49c7)
 	ld l, $e
@@ -1462,7 +1462,7 @@ ModifyEventFlags: ; ca92 (3:4a92)
 
 Func_cab3: ; cab3 (3:4ab3)
 	push hl
-	ld hl, [sp+$4]
+	ld hl, sp+$4
 	push bc
 	ld c, [hl]
 	inc hl

--- a/src/engine/home.asm
+++ b/src/engine/home.asm
@@ -805,7 +805,7 @@ JumpToFunctionInTable: ; 05ab (0:05ab)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 ; call function at [hl] if non-NULL
 CallIndirect: ; 05b6 (0:05b6)
@@ -822,7 +822,7 @@ CallIndirect: ; 05b6 (0:05b6)
 	pop af
 	; fallthrough
 CallHL: ; 05c1 (0:05c1)
-	jp [hl]
+	jp hl
 ; 0x5c2
 
 INCBIN "baserom.gbc",$05c2,$0663 - $05c2
@@ -968,7 +968,7 @@ BankpushHome: ; 0745 (0:0745)
 	push de
 	ld e, l
 	ld d, h
-	ld hl, [sp+$9]
+	ld hl, sp+$9
 	ld b, [hl]
 	dec hl
 	ld c, [hl]
@@ -976,7 +976,7 @@ BankpushHome: ; 0745 (0:0745)
 	ld [hl], b
 	dec hl
 	ld [hl], c
-	ld hl, [sp+$9]
+	ld hl, sp+$9
 	ldh a, [hBankROM]
 	ld [hld], a
 	ld [hl], $0
@@ -1006,7 +1006,7 @@ BankpushHome2: ; 076f (0:076f)
 	push de
 	ld e, l
 	ld d, h
-	ld hl, [sp+$9]
+	ld hl, sp+$9
 	ld b, [hl]
 	dec hl
 	ld c, [hl]
@@ -1014,7 +1014,7 @@ BankpushHome2: ; 076f (0:076f)
 	ld [hl], b
 	dec hl
 	ld [hl], c
-	ld hl, [sp+$9]
+	ld hl, sp+$9
 	ldh a, [hBankROM]
 	ld [hld], a
 	ld [hl], $0
@@ -1031,7 +1031,7 @@ BankpushHome2: ; 076f (0:076f)
 BankpopHome: ; 078e (0:078e)
 	push hl
 	push de
-	ld hl, [sp+$7]
+	ld hl, sp+$7
 	ld a, [hld]
 	call BankswitchHome
 	dec hl
@@ -1418,7 +1418,7 @@ RST18: ; 09ae (0:09ae)
 	push hl
 	push de
 	push af
-	ld hl, [sp+$d]
+	ld hl, sp+$d
 	ld d, [hl]
 	dec hl
 	ld e, [hl]
@@ -1441,7 +1441,7 @@ RST18: ; 09ae (0:09ae)
 	; fallthrough
 Func_09ce: ; 09ce (0:09ce)
 	call BankswitchHome
-	ld hl, [sp+$d]
+	ld hl, sp+$d
 	inc de
 	inc de
 	ld [hl], d
@@ -1464,7 +1464,7 @@ RST28: ; 09e9 (0:09e9)
 	push hl
 	push de
 	push af
-	ld hl, [sp+$d]
+	ld hl, sp+$d
 	ld d, [hl]
 	dec hl
 	ld e, [hl]
@@ -3770,7 +3770,7 @@ CopyLine: ; 1ea5 (0:1ea5)
 	add sp, -$20
 	push hl
 	push bc
-	ld hl, [sp+$4]
+	ld hl, sp+$4
 	dec b
 	dec b
 	push hl
@@ -3903,11 +3903,11 @@ Func_1f5f: ; 1f5f (0:1f5f)
 .asm_1f67
 	push hl
 	push bc
-	ld hl, [sp+$25]
+	ld hl, sp+$25
 	ld d, [hl]
-	ld hl, [sp+$27]
+	ld hl, sp+$27
 	ld a, [hl]
-	ld hl, [sp+$4]
+	ld hl, sp+$4
 	push hl
 .asm_1f72
 	ld [hli], a
@@ -3922,9 +3922,9 @@ Func_1f5f: ; 1f5f (0:1f5f)
 	ld c, b
 	ld b, $0
 	call Memcpy
-	ld hl, [sp+$24]
+	ld hl, sp+$24
 	ld a, [hl]
-	ld hl, [sp+$27]
+	ld hl, sp+$27
 	add [hl]
 	ld [hl], a
 	pop bc
@@ -7361,7 +7361,7 @@ RunOverworldScript: ; 3aed (0:3aed)
 	pop af
 	call BankswitchHome
 	pop bc
-	jp [hl]
+	jp hl
 ; 0x3b11
 
 INCBIN "baserom.gbc",$3b11,$3b21 - $3b11
@@ -7486,7 +7486,7 @@ Func_3bf5: ; 3bf5 (0:3bf5)
 INCBIN "baserom.gbc",$3c10,$3c45 - $3c10
 
 Func_3c45: ; 3c45 (0:3c45)
-	jp [hl]
+	jp hl
 ; 0x3c46
 
 INCBIN "baserom.gbc",$3c46,$3c48 - $3c46
@@ -7666,7 +7666,7 @@ Func_3df3: ; 3df3 (0:3df3)
 	push hl
 	ld a, BANK(Func_12c7f)
 	call BankswitchHome
-	ld hl, [sp+$5]
+	ld hl, sp+$5
 	ld a, [hl]
 	call Func_12c7f
 	call Func_0404
@@ -7708,7 +7708,7 @@ Bankswitch3dTo3f:: ; 3fe0 (0:3fe0)
 	pop af
 	ld bc, Bankswitch3d
 	push bc
-	jp [hl]
+	jp hl
 
 Bankswitch3d: ; 3fe0 (0:3fe0)
 	ld a, $3d


### PR DESCRIPTION
This fixes warnings like

```
warning: src/main.asm(4) -> engine/home.asm(808):
	'JP [HL]' is obsolete, use 'JP HL' instead.
```

and

```
warning: src/main.asm(4) -> engine/home.asm(971):
	'LD HL,[SP+e8]' is obsolete, use 'LD HL,SP+e8' instead.
```

on new builds of RGBDS.  Everything still compiles correctly with older versions (tested v0.2.5), at least as far as I can tell (I am not familiar with this toolchain).

See also: pret/pokered#147