### PR TITLE
Add CI Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Checkout rgbds
+        uses: actions/checkout@master
+        with:
+          path: rgbds
+          ref: v0.5.2
+          repository: gbdev/rgbds
+
+      - name: Install rgbds
+        working-directory: rgbds
+        run: |
+          sudo make install
+      - name: Remove rgbds
+        run: |
+          rm -rf rgbds
+      - name: Compare
+        if: ${{ github.repository_owner == 'pret' }}
+        run: |
+          make DEBUG=1 -j$(nproc) compare
+          if ! git diff-index --quiet HEAD --; then
+            echo 'Uncommitted changes detected:'
+            git diff-index HEAD --
+            return 1
+          fi
+      - name: Make
+        if: ${{ github.repository_owner != 'pret' }}
+        run: |
+          make -j$(nproc)
+          if ! git diff-index --quiet HEAD --; then
+            echo 'Uncommitted changes detected:'
+            git diff-index HEAD --
+            return 1
+          fi
+      - name: Checkout symbols
+        if: ${{ github.event_name == 'push' && github.repository_owner == 'pret' }}
+        uses: actions/checkout@master
+        with:
+          path: symbols
+          ref: symbols
+
+      - name: Move symbols
+        if: ${{ github.event_name == 'push' && github.repository_owner == 'pret' }}
+        run: |
+          cp -v *.sym symbols/
+      - name: Update symbols
+        if: ${{ github.event_name == 'push' && github.repository_owner == 'pret' }}
+        uses: EndBug/add-and-commit@v7
+        with:
+          branch: symbols
+          cwd: "./symbols"
+          add: "*.sym"
+          message: ${{ github.event.commits[0].message }}


### PR DESCRIPTION
The following is the `main.yml` from pret/pokecrystal without the Discord webhook. Not sure if that is needed/wanted. This should be able to be used to set up the Continous Integration.

This also includes what is needed to update a `symbols` branch like pokecrystal. I think all that is needed is to create a `symbols` branch with a blank history. However, you could confirm with Rangi that this would be the correct method.

Resolves #117